### PR TITLE
内部関数equalの実装と、compareがcompare_caseと同じ挙動をとっていたことの修正

### DIFF
--- a/satoriya/_/stltool.h
+++ b/satoriya/_/stltool.h
@@ -20,9 +20,9 @@
 #include	<climits>
 #include	<cstdlib>
 #include	<cstring>
-#define stricmp strcmp
-#define strnicmp strncmp
-#define strcasecmp strcmp
+#define stricmp _stricmp
+#define strnicmp _strnicmp
+#define strcasecmp _stricmp
 #include	<iostream>
 #include	<string>
 #include	<map>

--- a/satoriya/_/stltool.h
+++ b/satoriya/_/stltool.h
@@ -20,9 +20,11 @@
 #include	<climits>
 #include	<cstdlib>
 #include	<cstring>
+#ifdef _MSC_VER
 #define stricmp _stricmp
 #define strnicmp _strnicmp
 #define strcasecmp _stricmp
+#endif
 #include	<iostream>
 #include	<string>
 #include	<map>

--- a/satoriya/satori/satori_Kakko.cpp
+++ b/satoriya/satori/satori_Kakko.cpp
@@ -209,6 +209,14 @@ string	Satori::inc_call(
 		}
 		return	"";
 	}
+
+	if (iCallName == "equal") {
+		if (iArgv.size() == 2) {
+			const string &lhs = iArgv[0], &rhs = iArgv[1];
+			return itos(lhs == rhs);
+		}
+		return	"";
+	}
 	
 	if ( iCallName == "単語の追加" ) {
 
@@ -464,6 +472,7 @@ bool	Satori::CallReal(const string& iName, string& oResult, bool for_calc, bool 
 				inner_commands.insert("loop");
 				inner_commands.insert("remember");
 				inner_commands.insert("call");
+				inner_commands.insert("equal");
 				inner_commands.insert("バイト値");
 				inner_commands.insert("文の数");
 				inner_commands.insert("単語の追加");


### PR DESCRIPTION
*内部関数equalの実装
内部関数equalは、里々の等号演算子と機能として同等です
「ABC==ABC」が1を返す時、「（equal,ABC,ABC）」も1を返します
また、「ABC==ＡＢＣ」が0を返す時、「（equal,ABC,ＡＢＣ）」も0を返します

equalは、値が等価であることを確認したいが、等号演算子を使って比較するには不具合があるケースを回避する際に用います
例えば現行の等号演算子では「ほげ！＝＝ほげ！」という式を「（ほげ）！＝（＝ほげ！）」と認識し、目論見どおりに文字列を比較することが出来ません
「（equal,ほげ！,ほげ！）」と書けるようになることで、本来演算子のみでは行えなかったケースに対して、値が等価であることを確認することが可能となります

*compareがcompare_caseと同じ挙動をとっていた
VS2013への対応時に#define stricmp strcmpという置き換えが悪さをして上記の挙動を取るようになっていたようなのでそれの修正をしました