### PR TITLE
ul2zen関数追加、累計時の計算をunsigned longとして行うように変更

### DIFF
--- a/satoriya/_/stltool.cpp
+++ b/satoriya/_/stltool.cpp
@@ -812,6 +812,21 @@ string int2zen(int i) {
 	return	zen;
 }
 
+string ul2zen(unsigned long i) {
+	static const char*	ary[] = { "‚O", "‚P", "‚Q", "‚R", "‚S", "‚T", "‚U", "‚V", "‚W", "‚X" };
+
+	string	zen;
+
+	string	han = uitos(i);
+	const char* p = han.c_str();
+
+	for (; *p != '\0'; ++p) {
+		assert(*p >= '0' && *p <= '9');
+		zen += ary[*p - '0'];
+	}
+	return	zen;
+}
+
 int zen2int(const char *str)
 {
 	return stoi_internal(zen2han(str));

--- a/satoriya/_/stltool.h
+++ b/satoriya/_/stltool.h
@@ -547,6 +547,7 @@ T	round(T num, const int figure=0) {
 }
 
 string	int2zen(int i);
+string ul2zen(unsigned long i);
 
 int     zen2int(const char *str);
 inline int zen2int(const string &s)

--- a/satoriya/satori/satori_Kakko.cpp
+++ b/satoriya/satori/satori_Kakko.cpp
@@ -847,36 +847,36 @@ bool	Satori::CallReal(const string& iName, string& oResult, bool for_calc, bool 
 	}
 	//累計
 	else if (iName == "累計時") {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    time_t hour = sec / 60 / 60;
-	    oResult = int2zen(hour);
+	    unsigned long sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		unsigned long hour = sec / 60 / 60;
+	    oResult = ul2zen(hour);
 	}
 	else if (iName == "累計分" ) {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    time_t hour = sec / 60 / 60;
+		unsigned long  sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		unsigned long  hour = sec / 60 / 60;
 	    sec -= hour * 60 * 60;
-	    time_t minute = sec / 60;
-	    oResult = int2zen(minute);
+		unsigned long  minute = sec / 60;
+		oResult = ul2zen(minute);
 	}
 	else if (iName == "累計秒") {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    time_t hour = sec / 60 / 60;
+		unsigned long  sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		unsigned long  hour = sec / 60 / 60;
 	    sec -= hour * 60 * 60;
-	    time_t minute = sec / 60;
+		unsigned long  minute = sec / 60;
 	    sec -= minute * 60;
-	    oResult = int2zen(sec);
+		oResult = ul2zen(sec);
 	}
 	else if (iName == "単純累計秒") {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    oResult = int2zen(sec);
+		unsigned long  sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		oResult = ul2zen(sec);
 	}
 	else if (iName == "単純累計分") {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    oResult = int2zen(sec / 60);
+		unsigned long  sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		oResult = ul2zen(sec / 60);
 	}
 	else if (iName == "単純累計時") {
-	    time_t sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
-	    oResult = int2zen(sec / 60 / 60);
+		unsigned long  sec = posix_get_current_sec() - sec_count_at_load + sec_count_total;
+		oResult = ul2zen(sec / 60 / 60);
 	}
 	else if ( hankaku == "time_t" ) { time_t tm; time(&tm); oResult=int2zen(tm); }
 	else if ( iName == "最終トークからの経過秒" ) { oResult=int2zen(second_from_last_talk); }


### PR DESCRIPTION
VC++2005以降、time_tはlong longとしてtypedefされています
一方それ以前では、time_tはlong intとしてtypedefされているため、現行の累積時間関連の変数が、long intの最大値を超えた時点で不適当な値が出るようになっています
Mc155-4で、unsigned longを累計時間の管理に使うようになった為、この問題が起こるようになりました
例えば
＄ゴースト起動時間累計秒＝4293999083
の場合、
（累計時）ー＞ー２６８
と出力されます

unsigned long直書きでVC++2003でも最近のコンパイラでも同じ数値の範囲を扱えるようになるかと思うのですがいかがでしょうか