### PR TITLE
イベント「なでられ時の反応」と、システム変数「なでられ時実行イベント」の追加

### DIFF
--- a/satoriya/satori/satori.h
+++ b/satoriya/satori/satori.h
@@ -189,6 +189,7 @@ private:
 	bool	insert_nade_talk_at_other_talk;	// 喋ってる最中のなで反応有無
 	int		nade_valid_time_initializer;	// なでられ持続秒数（なでセッションの期限）
 	int		nade_sensitivity;				// なでられ我慢回数（発動までの回数）
+	bool	bool_of_action_when_ghost_is_stroked; //ゴーストがなでられた際の実行イベントの切り替え用
 
 	unsigned int mousedown_time;
 	strvec mousedown_reference_array;

--- a/satoriya/satori/satori_EventOperation.cpp
+++ b/satoriya/satori/satori_EventOperation.cpp
@@ -261,9 +261,14 @@ int	Satori::EventOperation(string iEvent, map<string,string> &oResponse)
 #endif
 			
 			if ( ret == 0 ) {
-				string	str = mReferences[3]+mReferences[4]+"‚È‚Å‚ç‚ê";
-				if ( talks.is_exist(str) )
-					script=GetSentence(str);
+				if (bool_of_action_when_ghost_is_stroked && talks.is_exist("‚È‚Å‚ç‚êŽž‚Ì”½‰ž")) {
+					script = GetSentence("‚È‚Å‚ç‚êŽž‚Ì”½‰ž");
+				}
+				else {
+					string	str = mReferences[3] + mReferences[4] + "‚È‚Å‚ç‚ê";
+					if (talks.is_exist(str))
+						script = GetSentence(str);
+				}
 				GetSender().sender() << "Talk: " << script << endl;
 			}
 			nade_count.clear();

--- a/satoriya/satori/satori_load_dict.h
+++ b/satoriya/satori/satori_load_dict.h
@@ -34,6 +34,7 @@ void	Satori::InitMembers() {
 	insert_nade_talk_at_other_talk=false;
 	nade_valid_time_initializer=2;
 	nade_sensitivity=60;
+	bool_of_action_when_ghost_is_stroked=false;
 
 	koro_count.clear();
 	koro_valid_time=0;

--- a/satoriya/satori/satori_tool.cpp
+++ b/satoriya/satori/satori_tool.cpp
@@ -790,6 +790,18 @@ bool	Satori::system_variable_operation(string key, string value, string* result)
 		return true;
 	}
 	
+	if (key == "なでられ時実行イベント") {
+		if (value == "なでられ時の反応") {
+			bool_of_action_when_ghost_is_stroked = true;
+			variables["なでられ時実行イベント"] = "なでられ時の反応";
+		}
+		else /* if ( value == "デフォルト" ) */ {
+			bool_of_action_when_ghost_is_stroked = false;
+			variables["なでられ時実行イベント"] = "デフォルト";
+		}
+		return true;
+	}
+	
 	if ( key == "なでられ持続秒数") {
 		nade_valid_time_initializer = zen2int(value);
 		return true;
@@ -857,6 +869,7 @@ bool	Satori::system_variable_operation(string key, string value, string* result)
 			type_of_communicate_search = COMSEARCH_DEFAULT;
 			variables["コミュニケートの検索方法"] = "里々";
 		}
+		return true;
 	}
 	
 	if ( key == "辞書フォルダ" ) {


### PR DESCRIPTION
「なでられ時実行イベント」へ文字列「なでられ時の反応」が代入されている際、イベント「なでられ時の反応」が辞書に存在すると、OnMouseMoveが辞書に存在しない場合、すべての反応が「なでられ時の反応」を経由して行われるようになる。

例：satori_conf.txtの＊初期化に以下の項を追加する。

＄なでられ時実行イベント【タブ】なでられ時の反応

この状態で辞書の任意の箇所に以下の文を追加する。

＊なでられ時の反応
：ほげー

OnMouseMoveが辞書内に存在しない場合、なでられ反応時に本来呼び出される「0hogeなでられ」などのかわりに、上記のイベントが呼び出される。
リファレンスはOnMouseMoveと変わらないので、

＊なでられ時の反応
＞（R3）（R4）なでられ

とすることで、既存のなでられ反応へと流れを繋ぐことができる。