### PR TITLE
辞書接頭辞と辞書拡張子が一部しか機能していなかったのを修正

### DIFF
--- a/satoriya/satori/satori_load_dict.cpp
+++ b/satoriya/satori/satori_load_dict.cpp
@@ -478,8 +478,8 @@ int Satori::LoadDicFolder(const string& i_base_folder)
 	{
 		const int len = it->size();
 		if ( len < dic_load_prefix.length() + (ext.length() < 4 ? ext.length() : 4)  ) { continue; } // Å’Zƒtƒ@ƒCƒ‹–¼‚ÍŽ«‘Ú“ªŽ« + min(Ž«‘Šg’£Žq, ".sat")
-		if ( it->compare(0,3,dic_load_prefix.c_str()) != 0 ) { continue; }
-		if ( it->compare(len-4,4,ext.c_str()) != 0 && it->compare(len-4,4,".sat") != 0 ) { continue; }
+		if ( it->compare(0,dic_load_prefix.length(),dic_load_prefix.c_str()) != 0 ) { continue; }
+		if ( it->compare(len-ext.length(),ext.length(),ext.c_str()) != 0 && it->compare(len-4,4,".sat") != 0 ) { continue; }
 
 		if ( LoadDictionary(i_base_folder + *it) ) {
 			++count;

--- a/satoriya/satori/satori_load_dict.cpp
+++ b/satoriya/satori/satori_load_dict.cpp
@@ -477,7 +477,7 @@ int Satori::LoadDicFolder(const string& i_base_folder)
 	for (std::vector<string>::const_iterator it=files.begin() ; it!=files.end() ; ++it)
 	{
 		const int len = it->size();
-		if ( len < 3 ) { continue; } // 最短ファイル名3文字以上
+		if ( len < dic_load_prefix.length() + (ext.length() < 4 ? ext.length() : 4)  ) { continue; } // 最短ファイル名は辞書接頭辞 + min(辞書拡張子, ".sat")
 		if ( it->compare(0,3,dic_load_prefix.c_str()) != 0 ) { continue; }
 		if ( it->compare(len-4,4,ext.c_str()) != 0 && it->compare(len-4,4,".sat") != 0 ) { continue; }
 


### PR DESCRIPTION
辞書接頭辞、辞書拡張子の両方とも
3文字でないと機能せず、それ以外の文字数だと
辞書が読み込まれていなかったのを修正しました。

ついでに、辞書接頭辞のみからなるファイル/フォルダを
DLLと同じフォルダに作成すると
out_of_range例外が発生していたのを修正しました。